### PR TITLE
Add linux paths for binaries

### DIFF
--- a/src/adapters/iosAdapter.ts
+++ b/src/adapters/iosAdapter.ts
@@ -163,6 +163,8 @@ export class IOSAdapter extends AdapterCollection {
 
         } else if (os.platform() === 'darwin') {
             return '/usr/local/bin/ios_webkit_debug_proxy';
+        } else if (os.platform() === 'linux') {
+            return '/usr/bin/ios_webkit_debug_proxy';
         }
 
         return null;
@@ -182,6 +184,8 @@ export class IOSAdapter extends AdapterCollection {
 
         } else if (os.platform() === 'darwin') {
             return '/usr/local/bin/ideviceinfo';
+        } else if (os.platform() === 'linux') {
+            return '/usr/bin/ideviceinfo';
         }
 
         return null;


### PR DESCRIPTION
This is all I needed to change to get it working on Linux. I didn't test it well enough but initially it loads the inspector and most of the functionality seems to work.