### PR TITLE
Stop flood of error TS6054 when building app..

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -15,7 +15,7 @@ const fs = require('fs')
 const path = require('path')
 
 const shellSources = [
-  'src/**/*',
+  'src/**/*.ts',
   'test/**/*.ts',
   'test/*.ts',
   'typings/globals/**/*.ts',


### PR DESCRIPTION
Building (after an initial build) caused:

$ npm start

> remotedebug-ios-webkit-adapter@0.1.9 start /Users/kris/projects/node/remotedebug-ios-webkit-adapter
> gulp build && node out/index.js

[11:43:32] Using gulpfile ~/projects/node/remotedebug-ios-webkit-adapter/gulpfile.js
[11:43:32] Starting 'build'...
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/adapters/adapter.js' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/adapters/adapter.js.map' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/adapters/adapterCollection.js' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/adapters/adapterCollection.js.map' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/adapters/adapterInterfaces.js' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/adapters/adapterInterfaces.js.map' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/adapters/iosAdapter.js' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/adapters/iosAdapter.js.map' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/adapters/testAdapter.js' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/adapters/testAdapter.js.map' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/index.js' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/index.js.map' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/logger.js' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/logger.js.map' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/protocols/ios/ios.js' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/protocols/ios/ios.js.map' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/protocols/ios/ios8.js' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/protocols/ios/ios8.js.map' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/protocols/ios/ios9.js' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/protocols/ios/ios9.js.map' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/protocols/ios/screencast.js' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/protocols/ios/screencast.js.map' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/protocols/protocol.js' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/protocols/protocol.js.map' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/protocols/target.js' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/protocols/target.js.map' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/server.js' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
error TS6054: File '/Users/kris/projects/node/remotedebug-ios-webkit-adapter/src/server.js.map' has unsupported extension. The only supported extensions are '.ts', '.tsx', '.d.ts'.
[11:43:34] TypeScript: 28 options errors
[11:43:34] TypeScript: emit succeeded (with errors)
[11:43:34] Finished 'build' after 2.15 s

This fixes that