### PR TITLE
Updated vs-libimobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Follow the instructions to install [ios-webkit-debug-proxy](https://github.com/g
 #### Windows
 All dependencies should be bundled. You should be good to go. 
 
-**iOS 10 on Windows**: Please be aware that iOS10 debugging might not work on Windows as the bundled version of [/ios-webkit- debug-proxy-win32](https://github.com/artygus/ios-webkit-debug-proxy-win32) is out of date.
+**iOS 10 on Windows**: Please be aware that iOS10 debugging might not work on Windows as the bundled version of [/ios-webkit- debug-proxy-win32](https://github.com/artygus/ios-webkit-debug-proxy-win32) may be out of date.
 
 #### OSX/Mac
 Make sure you have Homebrew installed, and run the following command to install [ios-webkit-debug-proxy](https://github.com/google/ios-webkit-debug-proxy) and [libimobiledevice](https://github.com/libimobiledevice/libimobiledevice)

--- a/package.json
+++ b/package.json
@@ -39,6 +39,6 @@
     "typescript": "2.2.2"
   },
   "optionalDependencies": {
-    "vs-libimobile": "^0.0.3"
+    "vs-libimobile": "^0.0.5"
   }
 }


### PR DESCRIPTION
With the vs-libimobile updated from 0.0.3 to 0.0.5, I was able to debug safari on iOS 10.3.2 with Windows.