### PR TITLE
fix: make sure target id is unique

### DIFF
--- a/src/adapters/adapter.ts
+++ b/src/adapters/adapter.ts
@@ -138,7 +138,7 @@ export class Adapter extends EventEmitter {
         debug('adapter.setTargetInfo', t, metadata)
 
         // Ensure there is a valid id
-        const id: string = (t.id || t.appId);
+        const id: string = (t.id || t.webSocketDebuggerUrl);
         t.id = id;
 
         // Set the adapter type


### PR DESCRIPTION
I found target pages was disordered  at chrome://inspect when pages share the same appIds. The source code show that remotedebug-ios-webkit-adapter is using appId as target identifier when id is not exist. But the appId is identify for applications, not target pages. 

Changing to `webSocketDebuggerUrl` seems not so elegant, but is the only unique field from ios-webkit-debug-proxy.