### PR TITLE
Windows 64-bit support for iOS 10 & 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules
 out
 typings
 npm-debug.log
+/.vs

--- a/README.md
+++ b/README.md
@@ -21,7 +21,11 @@ Follow the instructions to install [ios-webkit-debug-proxy](https://github.com/g
 #### Windows
 All dependencies should be bundled. You should be good to go. 
 
-**iOS 10 on Windows**: Please be aware that iOS11 debugging might not work on Windows as the bundled version of [/ios-webkit- debug-proxy-win32](https://github.com/artygus/ios-webkit-debug-proxy-win32) may be out of date.
+**iOS 10 & 11 on Windows**: Please be aware that iOS11 debugging might not work on Windows as the bundled version of [/ios-webkit- debug-proxy-win32](https://github.com/artygus/ios-webkit-debug-proxy-win32) may be out of date.
+
+**Windows 64-bit environments** require the following additional assets:
+1. Download the latest [Win64 release](https://github.com/google/ios-webkit-debug-proxy/releases/) ([v1.8](https://github.com/google/ios-webkit-debug-proxy/releases/download/v1.8/ios-webkit-debug-proxy-1.8-win64-bin.zip) at time of writing)
+2. Create a new folder named "x64" in `%AppData%\npm\node_modules\remotedebug-ios-webkit-adapter\node_modules\vs-libimobile\` (sibling to "lib") and extract the ios-webkit-debug-proxy-[ver]-win64-bin.zip archive there so that the architecture detection script in iosAdapter.js will resolve to `%AppData%\npm\node_modules\remotedebug-ios-webkit-adapter\node_modules\vs-libimobile\x64\ios_webkit_debug_proxy.exe` properly
 
 #### OSX/Mac
 Make sure you have Homebrew installed, and run the following command to install [ios-webkit-debug-proxy](https://github.com/google/ios-webkit-debug-proxy) and [libimobiledevice](https://github.com/libimobiledevice/libimobiledevice)

--- a/src/adapters/iosAdapter.ts
+++ b/src/adapters/iosAdapter.ts
@@ -143,7 +143,7 @@ export class IOSAdapter extends AdapterCollection {
         debug(`iOSAdapter.getProxyPath`)
         return new Promise((resolve, reject) => {
             if (os.platform() === 'win32') {
-                const proxy = path.resolve(__dirname, '../../node_modules/vs-libimobile/lib/ios_webkit_debug_proxy.exe');
+                const proxy = os.arch() === 'x64' ? path.resolve(__dirname, '../../node_modules/vs-libimobile/x64/ios_webkit_debug_proxy.exe') : path.resolve(__dirname, '../../node_modules/vs-libimobile/lib/ios_webkit_debug_proxy.exe');
                 try {
                     fs.statSync(proxy);
                     resolve(proxy)


### PR DESCRIPTION
+ Win x64 architecture detection in iosAdapter.ts
+ Updated readme with Win 64-bit instructions
+ exclude visual studio files