### PR TITLE
fix: return empty array in case of invalid in extractDisabledStyles

### DIFF
--- a/src/protocols/ios/ios.ts
+++ b/src/protocols/ios/ios.ts
@@ -748,7 +748,7 @@ export abstract class IOSProtocol extends ProtocolAdapter {
             } else if (styleText.substr(index, IOSProtocol.END_COMMENT.length) === IOSProtocol.END_COMMENT) {
                 if (startIndices.length === 0) {
                     // Invalid state
-                    return null;
+                    return [];
                 }
 
                 const startIndex = startIndices.pop();
@@ -773,7 +773,7 @@ export abstract class IOSProtocol extends ProtocolAdapter {
 
         if (startIndices.length !== 0) {
             // Invalid state
-            return null;
+            return [];
         }
 
         return styles;


### PR DESCRIPTION
Prevent TypeError @ https://github.com/RemoteDebug/remotedebug-ios-webkit-adapter/blob/74158b925fa03ce800fbcda3400248328d29fdf4/src/protocols/ios/ios.ts#L649