### PR TITLE
fix(iosAdapter): fixed issue when user has custom scoop path

### DIFF
--- a/src/adapters/iosAdapter.ts
+++ b/src/adapters/iosAdapter.ts
@@ -143,7 +143,9 @@ export class IOSAdapter extends AdapterCollection {
         debug(`iOSAdapter.getProxyPath`)
         return new Promise((resolve, reject) => {
             if (os.platform() === 'win32') {
-                const proxy = path.resolve(__dirname, process.env.USERPROFILE + '/scoop/apps/ios-webkit-debug-proxy/current/ios_webkit_debug_proxy.exe');
+                const proxy = process.env.SCOOP ? 
+								path.resolve(__dirname, process.env.SCOOP + '/apps/ios-webkit-debug-proxy/current/ios_webkit_debug_proxy.exe') :
+								path.resolve(__dirname, process.env.USERPROFILE + '/scoop/apps/ios-webkit-debug-proxy/current/ios_webkit_debug_proxy.exe');
                 try {
                     fs.statSync(proxy);
                     resolve(proxy)


### PR DESCRIPTION
I installed scoop on a custom path like:

    [environment]::setEnvironmentVariable('SCOOP','D:\Resources\Scoop','User')
    $env:SCOOP='D:\Resources\Scoop'
    iex (new-object net.webclient).downloadstring('https://get.scoop.sh')

When I tried to start, it failed because it could not find `ios_webkit_debug_proxy.exe`.
Which Is obvious when scoop is not installed in the user folder.
I added a check if there is a environment variable `SCOOP` and take this path.

