### PR TITLE
fix(ios): Call Log.entryAdded instead of Runtime.consoleAPICalled

### DIFF
--- a/src/protocols/ios/ios.ts
+++ b/src/protocols/ios/ios.ts
@@ -602,18 +602,23 @@ export abstract class IOSProtocol extends ProtocolAdapter {
             type = message.type;
         }
 
-        var consoleMessage = { 
-            type: type,
-            args: message.parameters || [],
-            executionContextId: this._lastPageExecutionContextId,
+        const consoleMessage = {
+            source: message.source,
+            level: type,
+            text: message.text,
+            lineNumber: message.line,
             timestamp: (new Date).getTime(),
+            url: message.url,
             stackTrace: message.stackTrace ? {
                 callFrames: message.stackTrace
-            } : undefined
-        }
+            } : undefined,
+            networkRequestId: message.networkRequestId,
+        };
 
-        this._target.fireEventToTools('Runtime.consoleAPICalled', consoleMessage);
-        
+        this._target.fireEventToTools('Log.entryAdded', {
+            entry: consoleMessage
+        });
+
         return Promise.resolve(null);
     }
 


### PR DESCRIPTION
Hi,

Related to: #136 and #114 

Instead of using the [Runtime.consoleAPICalled](https://chromedevtools.github.io/devtools-protocol/1-3/Runtime#event-consoleAPICalled) to handle **Console.messageAdded** event, I propose to use the [Log.entryAdded](https://chromedevtools.github.io/devtools-protocol/1-3/Log#event-entryAdded) event which seems more appropriate.

In my case: 
![fixios1](https://user-images.githubusercontent.com/1839713/54694348-63674c80-4b28-11e9-9339-8a3eed2bccb2.png)

... render to:
![fixios2](https://user-images.githubusercontent.com/1839713/54694369-6cf0b480-4b28-11e9-89e2-34c1f470c96a.png)

I tested this fix on an iPad iOS 12.1.4. Before this change, I also got the empty error messages.

I don't know if the current iOS adapter was for a specific iOS version (like ios8.ts and ios9.ts), so perhaps we need to keep the last adapter for iOS 10/11 and create a new adapter for iOS 12 and insert this change in this new adapter.