### PR TITLE
Change the path to vs-libimobile

### DIFF
--- a/src/adapters/iosAdapter.ts
+++ b/src/adapters/iosAdapter.ts
@@ -169,7 +169,7 @@ export class IOSAdapter extends AdapterCollection {
         debug(`iOSAdapter.getDeviceInfoPath`)
         return new Promise((resolve, reject) => {
             if (os.platform() === 'win32') {
-                const proxy = path.resolve(__dirname, process.env.USERPROFILE + '/AppData/Roaming/npm/node_modules/vs-libimobile/lib/ideviceinfo.exe');
+                const proxy = path.resolve(__dirname, '../../../vs-libimobile/lib/ideviceinfo.exe');
                 try {
                     fs.statSync(proxy);
                     resolve(proxy);


### PR DESCRIPTION
Change the path to vs-libimobile for custom NPM Prefix path. NPM's global node_modules folder isn't always under USERPROFILE/AppData/Roaming/npm, which can be modified by "npm config set prefix".
These changes solved the problem in #79 for me.