### PR TITLE
Upgrades Gulp from version 3 to 4 for Node 12 compatibility.

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -55,7 +55,7 @@ gulp.task('lint', function () {
     .pipe(tslint.report('verbose'))
 })
 
-gulp.task('test', ['build-tests'], function () {
+gulp.task('test', gulp.series('build-tests', function () {
   process.env.NODE_ENV = 'development'
   return gulp.src('out/test/**/*.test.js', { read: false })
     .pipe(mocha({ ui: 'tdd' }))
@@ -63,13 +63,13 @@ gulp.task('test', ['build-tests'], function () {
       log(e ? e.toString() : 'error in test task!')
       this.emit('end')
     })
-})
+}))
 
-gulp.task('watch-test', ['build-tests'], function () {
+gulp.task('watch-test', gulp.series('build-tests', function () {
   return gulp.watch(shellSources, ['build-tests'])
-})
+}))
 
-gulp.task('watch', ['build'], function () {
+gulp.task('watch', gulp.series('build', function () {
   const all = shellSources
   gulp.watch(all, ['build'])
-})
+}))

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "ws": "^1.1.0"
   },
   "devDependencies": {
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.2",
     "gulp-mocha": "^2.2.0",
     "gulp-sourcemaps": "^1.6.0",
     "gulp-tslint": "^7.1.0",


### PR DESCRIPTION
This should fix the builds failing for new pull requests. This does not upgrade any other dependencies, and as such leaves a few modules that have known vulnerabilities. A complete dependency upgrade should probably be a separate pull request, though.