### PR TITLE
Support detecting simulator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -7,8 +7,9 @@ var info = require('../package.json');
 process.title = 'remotedebug-ios-webkit-adapter';
 
 let argv = optimist
-  .usage('Usage: $0 -p [num]')
+  .usage('Usage: $0 -p [num] -s [id]')
   .alias('p', 'port').describe('p', 'the adapter listerning post').default('p', 9000)
+  .alias('s', 'sim-udid').describe('s', 'simulator udid')
   .describe('version', 'prints current version').boolean('boolean')
   .argv;
 
@@ -22,9 +23,14 @@ if (argv.help) {
   process.exit(0);
 }
 
+if (argv['sim-udid'] && process.platform !== 'darwin') {
+  console.error('Simulator debugging is only supported on mac os');
+  process.exit(1);
+}
+
 const server = new ProxyServer();
 
-server.run(argv.port).then(port => {
+server.run(argv.port, argv['sim-udid']).then(port => {
   console.log(`remotedebug-ios-webkit-adapter is listening on port ${port}`);
 }).catch(err => {
   console.error('remotedebug-ios-webkit-adapter failed to run with the following error:', err)

--- a/src/server.ts
+++ b/src/server.ts
@@ -44,7 +44,7 @@ export class ProxyServer extends EventEmitter {
 
         // Start server and return the port number
         this._hs.listen(this._serverPort);
-        const port = this._hs.address().port;
+        const port = (<AddressInfo>this._hs.address()).port;
 
         const settings = await IOSAdapter.getProxySettings({
             proxyPath: null,


### PR DESCRIPTION
google/ios-webkit-debug-proxy#306 introduced passing the simulator web inspector socket in to ios_webkit_debug_proxy. The socket can be looked up using `lsof -aUc launchd_sim` and finding the matching socket based off the provided UDID, I went this route (as opposed to a user providing the socket) as I figured it would be easier to find the UDID.

This is still pretty rough (exception handling could be improved), but I wanted to push a PR early to see whether this would be a welcome addition

This also requires ios-webkit-debug-proxy@1.8.5