### PR TITLE
BUGFIX: Fixed document.registerElement is not a function error in Chrome 80

### DIFF
--- a/src/adapters/adapter.ts
+++ b/src/adapters/adapter.ts
@@ -155,7 +155,7 @@ export class Adapter extends EventEmitter {
         // Overwrite the real endpoint with the url of our proxy multiplexor
         t.webSocketDebuggerUrl = `${this._proxyUrl}${this._id}/${t.id}`;
         let wsUrl = `${this._proxyUrl.replace('ws://', '')}${this._id}/${t.id}`;
-        t.devtoolsFrontendUrl = `https://chrome-devtools-frontend.appspot.com/serve_file/@7d149ef5473e980f0b3babd4d0f2839cb9338e73/inspector.html?experiments=true&remoteFrontend=screencast&ws=${wsUrl}`;
+        t.devtoolsFrontendUrl = `https://chrome-devtools-frontend.appspot.com/serve_file/@fcea73228632975e052eb90fcf6cd1752d3b42b4/inspector.html?experiments=true&remoteFrontend=screencast&ws=${wsUrl}`;
 
         return t;
     }


### PR DESCRIPTION
With Chrome 80 `document.registerElement` has been removed completely, due to the remote inspector seemingly using an older hash it was not loading a version compatible with this change. I've updated the hash to be closer to Chromium 80's release hash. This appears to solve #183 for me at least on Windows 10.