### PR TITLE
Read device version from ios-webkit-debug-proxy

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ Install [ios-webkit-debug-proxy](https://github.com/google/ios-webkit-debug-prox
 ```
 scoop bucket add extras
 scoop install ios-webkit-debug-proxy
-npm install -g vs-libimobile
 ```
 
 

--- a/src/adapters/adapterInterfaces.ts
+++ b/src/adapters/adapterInterfaces.ts
@@ -28,6 +28,7 @@ export interface IAdapterOptions {
 export interface IIOSDeviceTarget {
     deviceId: string;
     deviceName: string;
+    deviceOSVersion: string;
     url: string;
     version: string;
 }


### PR DESCRIPTION
Since ios-webkit-debug-proxy 1.8.5 it is possible to get device OS version from json, no need to use [vs-libimobile package](https://www.npmjs.com/package/vs-libimobile) it's pretty old and doesn't seem to work with ios 13 devices